### PR TITLE
Add pytest test suite and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest jsonschema
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     extras_require={
         "dev": [
             "pytest>=7.0.0",
+            "jsonschema>=4.0.0",
             "black>=23.0.0",
             "flake8>=6.0.0",
         ],

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,114 @@
+# Testing guide
+
+This suite is small on purpose. It exists to catch the failure modes that
+matter for an election-night scraper, not to chase coverage numbers.
+
+## Running the suite
+
+```bash
+pip install -e ".[dev]"
+pytest tests/
+```
+
+Tests do not touch the network and do not launch Chrome. The full suite
+runs in well under a second; if a new test makes that materially slower,
+something is wrong with the test, not the suite.
+
+## What we test, and why
+
+The scrapers have three classes of code:
+
+1. **Pure parsing logic** — turns HTML / PDF text / XML into a JSON
+   payload (`_parse`, `_parse_page_text`, `_parse_election`, helpers
+   like `_extract_base_url`, `_deduplicate_contests`).
+2. **Security boundary** — `validate_url`, `validate_and_secure_filepath`,
+   the `ALLOWED_DOMAINS` whitelists.
+3. **Network / browser orchestration** — Selenium driver setup,
+   CloudFront detection, retry loops, rate limiting.
+
+Tests cover **(1) and (2) only**. Group (3) is integration territory
+and is exercised manually against live county sites; mocking Selenium
+in detail produces tests that pass while the real thing breaks.
+
+The bar for a unit test here: it should fail loudly the next time a
+county changes its HTML, and it should never fail for a reason
+unrelated to the code under test.
+
+## The fixture-first pattern
+
+`tests/fixtures/` holds minimal hand-written reproductions of each
+upstream format — not full real captures. A good fixture is the
+shortest input that exercises every quirk the parser has to tolerate.
+For example, `mendocino_minimal.html` deliberately includes:
+
+- The `<meta>` tags the turnout numbers come from.
+- A duplicated `STATE PROPOSITION 50` table, because SSRS renders the
+  same contest twice and the parser must dedupe.
+- Header rows the parser must skip (`Choice`, `Party`, `Cast Votes:`).
+- An all-caps banner row (`MENDOCINO COUNTY, CALIFORNIA`) that looks
+  like a contest title but isn't.
+
+When a county changes its upstream output, update the fixture to
+match the new shape and add a regression test for whatever broke.
+Don't replace the whole fixture with a fresh real capture — that
+defeats the point of keeping it minimal and readable.
+
+## Why we bypass `__init__`
+
+`BaseScraper.__init__` calls `validate_url(url)` and constructs a
+`requests.Session`. Neither is interesting for parser tests, and the
+session creation drags in `urllib3` retry config we don't want to
+exercise here. Tests build instances via the `make_scraper()` helper
+in `conftest.py`:
+
+```python
+scraper = make_scraper(MendocinoScraper, url, county_name="Mendocino")
+data = scraper._parse(soup)
+```
+
+That uses `cls.__new__(cls)` and binds only the attributes the
+parser actually reads. If a parser starts depending on something
+else — say `self.session` — add it to `make_scraper()` rather than
+spreading per-test setup.
+
+## Cross-module drift checks
+
+`clarity_scraper.py` and `multi_platform_scraper.py` each define
+their own `validate_url`, `validate_and_secure_filepath`,
+`ALLOWED_DOMAINS`, and `ALLOWED_FILE_EXTENSIONS`. These two copies
+have drifted in the past. The tests in `test_security.py` are
+parametrized across both modules so a fix applied to one and not
+the other fails the suite. There is also an explicit subset check:
+clarity's whitelist must stay a subset of the multi-platform one.
+
+If you find yourself disabling a drift test, fix the divergence
+instead — or, better, extract the shared code into one place.
+
+## The JSON output schema is the contract
+
+`test_output_schema.py` validates every file in `data/samples/`
+against an explicit JSON Schema for the Clarity output envelope.
+Downstream consumers — CMS imports, results pages, dashboards —
+rely on this shape. The rule:
+
+- **Adding** a documented field: update the schema, add a test for it.
+- **Removing** a documented field: it's a breaking change. Bump
+  whatever version downstream consumers track and call it out.
+- **Adding** an undocumented field: fine, the schema sets
+  `additionalProperties: true` on purpose so scrapers can carry
+  county-specific extras.
+
+## Adding a test for a new county
+
+1. Capture a tiny representative slice of the upstream output in
+   `tests/fixtures/<county>_<format>.{html,txt,xml}`. Keep it under
+   ~100 lines if you can; trim aggressively.
+2. Add a `_<county>_data` helper in `test_parsers.py` that builds
+   a scraper via `make_scraper()` and runs the parser against the
+   fixture.
+3. Write assertions for: voter turnout numbers, page title, contest
+   titles, and at least one choice's votes + percentage. Those four
+   are the fields downstream consumers actually publish.
+4. If the parser has a quirk-handling branch (dedupe, skip rows,
+   multi-column layout), add a test that exercises it directly so
+   regressions are obvious from the failure name.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,15 +7,14 @@ without requiring an editable install.
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 SAMPLES = ROOT / "data" / "samples"
-
-
-import pytest
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+"""Shared pytest fixtures and path setup.
+
+Adds the project root to sys.path so `from src.* import ...` works
+without requiring an editable install.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+SAMPLES = ROOT / "data" / "samples"
+
+
+import pytest
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    return FIXTURES
+
+
+@pytest.fixture
+def samples_dir() -> Path:
+    return SAMPLES
+
+
+def make_scraper(cls, url: str, county_name: str = "Test County"):
+    """Build a scraper instance without running BaseScraper.__init__.
+
+    BaseScraper.__init__ calls validate_url() and creates a requests
+    Session — both unnecessary (and the latter slow) for parser tests.
+    Tests only need the parsing methods, which read self.url and
+    self.county_name.
+    """
+    inst = cls.__new__(cls)
+    inst.url = url
+    inst.county_name = county_name
+    return inst

--- a/tests/fixtures/mendocino_minimal.html
+++ b/tests/fixtures/mendocino_minimal.html
@@ -1,0 +1,91 @@
+<html>
+<head>
+<meta name="ElectionTitle" content="Statewide Special Election - November 4, 2025"/>
+<meta name="ReportGeneratedDate" content="11/05/2025 09:00 AM"/>
+<meta name="TotalRegisteredVoters" content="51,234"/>
+<meta name="TotalTabulatedBallots" content="22,617"/>
+<meta name="TotalPrecintsSplits" content="80"/>
+<meta name="TotalNumberReportingByPrecincts" content="80"/>
+</head>
+<body>
+<table>
+<tr><td>FINAL OFFICIAL REPORT - WEB</td></tr>
+<tr><td>MENDOCINO COUNTY, CALIFORNIA</td></tr>
+<tr><td>STATEWIDE SPECIAL ELECTION</td></tr>
+</table>
+
+<table>
+<tr><td>STATE PROPOSITION 50</td></tr>
+<tr>
+  <th>Choice</th><th>Party</th><th></th>
+  <th>Election Day Voting</th><th></th><th></th>
+  <th>Absentee Voting</th><th></th><th></th>
+  <th>Total</th><th></th>
+</tr>
+<tr>
+  <td>YES</td><td></td><td></td>
+  <td>1,200</td><td>55.00%</td><td></td>
+  <td>9,800</td><td>62.00%</td><td></td>
+  <td>11,000</td><td>61.10%</td>
+</tr>
+<tr>
+  <td>NO</td><td></td><td></td>
+  <td>980</td><td>45.00%</td><td></td>
+  <td>6,020</td><td>38.00%</td><td></td>
+  <td>7,000</td><td>38.90%</td>
+</tr>
+<tr>
+  <td>Cast Votes:</td><td></td><td></td>
+  <td>2,180</td><td></td><td></td>
+  <td>15,820</td><td></td><td></td>
+  <td>18,000</td><td></td>
+</tr>
+</table>
+
+<table>
+<tr><td>MEASURE A SCHOOL BOND</td></tr>
+<tr>
+  <th>Choice</th><th>Party</th><th></th>
+  <th>Election Day Voting</th><th></th><th></th>
+  <th>Absentee Voting</th><th></th><th></th>
+  <th>Total</th><th></th>
+</tr>
+<tr>
+  <td>YES</td><td></td><td></td>
+  <td>800</td><td>60.00%</td><td></td>
+  <td>4,200</td><td>70.00%</td><td></td>
+  <td>5,000</td><td>68.49%</td>
+</tr>
+<tr>
+  <td>NO</td><td></td><td></td>
+  <td>533</td><td>40.00%</td><td></td>
+  <td>1,800</td><td>30.00%</td><td></td>
+  <td>2,300</td><td>31.51%</td>
+</tr>
+</table>
+
+<!-- Duplicate of the first contest — SSRS sometimes renders the same -->
+<!-- contest twice. The parser must dedupe by title. -->
+<table>
+<tr><td>STATE PROPOSITION 50</td></tr>
+<tr>
+  <th>Choice</th><th>Party</th><th></th>
+  <th>Election Day Voting</th><th></th><th></th>
+  <th>Absentee Voting</th><th></th><th></th>
+  <th>Total</th><th></th>
+</tr>
+<tr>
+  <td>YES</td><td></td><td></td>
+  <td>1,200</td><td>55.00%</td><td></td>
+  <td>9,800</td><td>62.00%</td><td></td>
+  <td>11,000</td><td>61.10%</td>
+</tr>
+<tr>
+  <td>NO</td><td></td><td></td>
+  <td>980</td><td>45.00%</td><td></td>
+  <td>6,020</td><td>38.00%</td><td></td>
+  <td>7,000</td><td>38.90%</td>
+</tr>
+</table>
+</body>
+</html>

--- a/tests/fixtures/napa_summary.txt
+++ b/tests/fixtures/napa_summary.txt
@@ -1,0 +1,22 @@
+Napa County Registrar of Voters
+Statewide Special Election - November 4, 2025
+Summary Report
+
+Precincts Reported: 65 of 65 (100.00%)
+
+Voter Turnout
+Election Day  Vote by Mail  Total
+1,234         51,175        52,409
+Total  52,409  86,390  60.67%
+
+State Proposition 50 (Vote for 1)
+Candidate  Party  Total
+YES                    34,500  65.83%
+NO                     17,909  34.17%
+Total Votes 52,409
+
+Measure F School District (Vote for 1)
+Candidate  Party  Total
+YES                    8,200  62.50%
+NO                     4,920  37.50%
+Total Votes 13,120

--- a/tests/fixtures/solano_summary.txt
+++ b/tests/fixtures/solano_summary.txt
@@ -1,0 +1,18 @@
+Solano County Registrar of Voters
+Statewide Special Election - November 4, 2025
+Official Summary Results - SIGNED
+
+Voter Turnout
+145,294 of 277,461 = 52.37%
+
+Precincts Reporting 159 of 159 = 100.00%
+
+STATE PROPOSITION 50
+Choice                 ED Votes  ED %    VBM Votes  VBM %   Prov Votes  Prov %  Total Votes  Total %
+YES                    9,821     51.14%  80,903     65.42%  1,646       74.58%  92,370       63.67%
+NO                     9,383     48.86%  42,750     34.58%  561         25.42%  52,694       36.33%
+
+MEASURE B FAIRFIELD
+Choice                 ED Votes  ED %    VBM Votes  VBM %   Prov Votes  Prov %  Total Votes  Total %
+YES                    2,100     55.00%  18,400     62.00%  300         70.00%  20,800       61.50%
+NO                     1,720     45.00%  11,300     38.00%  130         30.00%  13,150       38.50%

--- a/tests/test_clarity_helpers.py
+++ b/tests/test_clarity_helpers.py
@@ -1,0 +1,45 @@
+"""Tests for small pure helpers on ClarityScraper."""
+
+from src.clarity_scraper import ClarityScraper
+
+from .conftest import make_scraper
+
+
+VALID_URL = "https://results.enr.clarityelections.com/CA/Marin/124182/web.345435/#/summary"
+
+
+def test_extract_base_url_strips_fragment():
+    scraper = make_scraper(ClarityScraper, VALID_URL)
+    assert scraper._extract_base_url(VALID_URL) == (
+        "https://results.enr.clarityelections.com/CA/Marin/124182/web.345435"
+    )
+
+
+def test_extract_base_url_strips_trailing_slash():
+    scraper = make_scraper(ClarityScraper, VALID_URL)
+    assert scraper._extract_base_url("https://clarityelections.com/x/") == (
+        "https://clarityelections.com/x"
+    )
+
+
+def test_deduplicate_contests_keeps_first_occurrence():
+    scraper = make_scraper(ClarityScraper, VALID_URL)
+    contests = [
+        {"title": "Proposition 50", "choices": ["a"]},
+        {"title": "Measure A", "choices": ["b"]},
+        {"title": "Proposition 50", "choices": ["duplicate"]},
+    ]
+    out = scraper._deduplicate_contests(contests)
+    assert [c["title"] for c in out] == ["Proposition 50", "Measure A"]
+    assert out[0]["choices"] == ["a"]
+
+
+def test_deduplicate_contests_drops_titleless_entries():
+    scraper = make_scraper(ClarityScraper, VALID_URL)
+    contests = [
+        {"title": None, "choices": []},
+        {"title": "", "choices": []},
+        {"title": "Real", "choices": []},
+    ]
+    out = scraper._deduplicate_contests(contests)
+    assert [c["title"] for c in out] == ["Real"]

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -1,0 +1,106 @@
+"""Validate every sample JSON in data/samples/ against the documented
+output schema. This is the contract downstream consumers (CMS imports,
+results pages, dashboards) rely on.
+
+Adding a new field to scraper output requires updating the schema in
+this file. Removing a documented field intentionally fails the suite.
+"""
+
+import json
+
+import jsonschema
+import pytest
+
+
+# Inner per-county payload — matches what each ClarityScraper /
+# multi-platform scraper returns from .scrape().
+COUNTY_PAYLOAD_SCHEMA = {
+    "type": "object",
+    "required": ["url", "page_title", "voter_turnout", "contests"],
+    "properties": {
+        "timestamp": {"type": "string"},
+        "url": {"type": "string", "format": "uri"},
+        "county_name": {"type": "string"},
+        "page_title": {"type": "string"},
+        "last_updated": {"type": ["string", "null"]},
+        "voter_turnout": {
+            "type": "object",
+            "properties": {
+                "ballots_cast": {"type": "integer", "minimum": 0},
+                "registered_voters": {"type": "integer", "minimum": 0},
+                "turnout_percentage": {"type": "number", "minimum": 0},
+                "precincts_reported": {"type": "string"},
+            },
+            "additionalProperties": True,
+        },
+        "contests": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["title"],
+                "properties": {
+                    "title": {"type": "string", "minLength": 1},
+                    "precincts_reporting": {"type": "string"},
+                    "choices": {"type": "array"},
+                },
+                "additionalProperties": True,
+            },
+        },
+    },
+    "additionalProperties": True,
+}
+
+
+# Outer Clarity envelope, as written by ClarityScraper.scrape().
+CLARITY_OUTPUT_SCHEMA = {
+    "type": "object",
+    "required": ["scrape_timestamp"],
+    "properties": {
+        "scrape_timestamp": {"type": "string"},
+        "json_data": {"type": ["object", "null"]},
+        "selenium_data": {
+            "anyOf": [{"type": "null"}, COUNTY_PAYLOAD_SCHEMA],
+        },
+    },
+    "additionalProperties": True,
+}
+
+
+def _sample_files(samples_dir):
+    return sorted(samples_dir.glob("*.json"))
+
+
+def test_samples_directory_is_populated(samples_dir):
+    files = _sample_files(samples_dir)
+    assert files, f"No sample JSON files in {samples_dir}"
+
+
+@pytest.mark.parametrize(
+    "sample_path",
+    _sample_files(__import__("pathlib").Path(__file__).resolve().parent.parent
+                  / "data" / "samples"),
+    ids=lambda p: p.name,
+)
+def test_sample_matches_clarity_schema(sample_path):
+    payload = json.loads(sample_path.read_text())
+    jsonschema.validate(payload, CLARITY_OUTPUT_SCHEMA)
+
+
+@pytest.mark.parametrize(
+    "sample_path",
+    _sample_files(__import__("pathlib").Path(__file__).resolve().parent.parent
+                  / "data" / "samples"),
+    ids=lambda p: p.name,
+)
+def test_sample_has_nonempty_results(sample_path):
+    """Every published sample should have at least one contest and a
+    plausible voter turnout block — otherwise we're shipping empty
+    fixtures that mask scraper regressions."""
+    payload = json.loads(sample_path.read_text())
+    inner = payload.get("selenium_data") or payload.get("json_data")
+    assert inner, f"{sample_path.name}: no selenium_data or json_data payload"
+    assert inner.get("contests"), f"{sample_path.name}: no contests captured"
+    turnout = inner.get("voter_turnout") or {}
+    assert turnout.get("ballots_cast", 0) > 0, (
+        f"{sample_path.name}: ballots_cast missing or zero"
+    )

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -11,6 +11,8 @@ import json
 import jsonschema
 import pytest
 
+from .conftest import SAMPLES as SAMPLES_DIR
+
 
 # Inner per-county payload — matches what each ClarityScraper /
 # multi-platform scraper returns from .scrape().
@@ -77,8 +79,7 @@ def test_samples_directory_is_populated(samples_dir):
 
 @pytest.mark.parametrize(
     "sample_path",
-    _sample_files(__import__("pathlib").Path(__file__).resolve().parent.parent
-                  / "data" / "samples"),
+    _sample_files(SAMPLES_DIR),
     ids=lambda p: p.name,
 )
 def test_sample_matches_clarity_schema(sample_path):
@@ -88,8 +89,7 @@ def test_sample_matches_clarity_schema(sample_path):
 
 @pytest.mark.parametrize(
     "sample_path",
-    _sample_files(__import__("pathlib").Path(__file__).resolve().parent.parent
-                  / "data" / "samples"),
+    _sample_files(SAMPLES_DIR),
     ids=lambda p: p.name,
 )
 def test_sample_has_nonempty_results(sample_path):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,155 @@
+"""Fixture-driven tests for the per-county parsers.
+
+These exercise the pure parsing logic — _parse() / _parse_page_text() —
+without any network or Selenium activity. The fixtures in tests/fixtures/
+are minimal hand-written reproductions of the real upstream formats:
+SSRS HTML for Mendocino, PDF-extracted text for Napa and Solano. They
+intentionally include the quirks the scrapers have to tolerate
+(duplicate contests, all-caps title rows, "Cast Votes" summary rows).
+
+If a county's upstream HTML structure changes and the parser breaks,
+the corresponding fixture should be updated to match — this is the
+regression net the project did not have before.
+"""
+
+from bs4 import BeautifulSoup
+
+from src.multi_platform_scraper import (
+    MendocinoScraper,
+    NapaScraper,
+    SolanoScraper,
+)
+
+from .conftest import make_scraper
+
+
+# ---------------------------------------------------------------------------
+# Mendocino — SSRS HTML
+# ---------------------------------------------------------------------------
+
+
+def _mendocino_data(fixtures_dir):
+    html = (fixtures_dir / "mendocino_minimal.html").read_text()
+    soup = BeautifulSoup(html, "html.parser")
+    scraper = make_scraper(
+        MendocinoScraper,
+        "http://www.co.mendocino.ca.us/acr/cgi-bin/currentFR.pl",
+        county_name="Mendocino",
+    )
+    return scraper._parse(soup)
+
+
+def test_mendocino_extracts_voter_turnout(fixtures_dir):
+    data = _mendocino_data(fixtures_dir)
+    turnout = data["voter_turnout"]
+    assert turnout["registered_voters"] == 51234
+    assert turnout["ballots_cast"] == 22617
+    assert turnout["turnout_percentage"] == 44.14
+    assert turnout["precincts_reported"] == "80 of 80"
+
+
+def test_mendocino_extracts_page_title_and_last_updated(fixtures_dir):
+    data = _mendocino_data(fixtures_dir)
+    assert data["page_title"] == "Statewide Special Election - November 4, 2025"
+    assert data["last_updated"] == "11/05/2025 09:00 AM"
+    assert data["county_name"] == "Mendocino"
+
+
+def test_mendocino_dedupes_repeated_contest(fixtures_dir):
+    data = _mendocino_data(fixtures_dir)
+    titles = [c["title"] for c in data["contests"]]
+    # Fixture has STATE PROPOSITION 50 listed twice; parser should dedupe.
+    assert titles.count("STATE PROPOSITION 50") == 1
+    assert "MEASURE A SCHOOL BOND" in titles
+
+
+def test_mendocino_extracts_choice_totals(fixtures_dir):
+    data = _mendocino_data(fixtures_dir)
+    prop50 = next(c for c in data["contests"] if c["title"] == "STATE PROPOSITION 50")
+    yes = next(ch for ch in prop50["choices"] if ch["name"] == "YES")
+    no = next(ch for ch in prop50["choices"] if ch["name"] == "NO")
+    assert yes["votes"] == "11000"
+    assert yes["percentage"] == "61.10%"
+    assert no["votes"] == "7000"
+
+
+def test_mendocino_skips_summary_rows(fixtures_dir):
+    """Cast Votes / Undervotes / Overvotes rows must not appear as choices."""
+    data = _mendocino_data(fixtures_dir)
+    for contest in data["contests"]:
+        names = [c["name"] for c in contest["choices"]]
+        for forbidden in ("Cast Votes:", "Undervotes:", "Overvotes:", "Choice"):
+            assert forbidden not in names
+
+
+# ---------------------------------------------------------------------------
+# Napa — PDF-extracted text
+# ---------------------------------------------------------------------------
+
+
+def _napa_data(fixtures_dir):
+    text = (fixtures_dir / "napa_summary.txt").read_text()
+    scraper = make_scraper(
+        NapaScraper,
+        "https://www.napacounty.gov/DocumentCenter/View/39913/",
+        county_name="Napa",
+    )
+    return scraper._parse(text)
+
+
+def test_napa_extracts_voter_turnout(fixtures_dir):
+    data = _napa_data(fixtures_dir)
+    turnout = data["voter_turnout"]
+    assert turnout["ballots_cast"] == 52409
+    assert turnout["registered_voters"] == 86390
+    assert turnout["turnout_percentage"] == 60.67
+    assert turnout["precincts_reported"] == "65 of 65 (100.00%)"
+
+
+def test_napa_extracts_page_title(fixtures_dir):
+    data = _napa_data(fixtures_dir)
+    assert "Statewide Special Election" in data["page_title"]
+
+
+def test_napa_extracts_contests(fixtures_dir):
+    data = _napa_data(fixtures_dir)
+    titles = [c["title"] for c in data["contests"]]
+    assert any("Proposition 50" in t for t in titles)
+
+
+# ---------------------------------------------------------------------------
+# Solano — PDF-extracted text
+# ---------------------------------------------------------------------------
+
+
+def _solano_data(fixtures_dir):
+    text = (fixtures_dir / "solano_summary.txt").read_text()
+    scraper = make_scraper(
+        SolanoScraper,
+        "https://content.solanocounty.gov/sites/default/files/2026-01/Official_Summary_Results_-_SIGNED.pdf",
+        county_name="Solano",
+    )
+    return scraper._parse(text)
+
+
+def test_solano_extracts_voter_turnout(fixtures_dir):
+    data = _solano_data(fixtures_dir)
+    turnout = data["voter_turnout"]
+    assert turnout["ballots_cast"] == 145294
+    assert turnout["registered_voters"] == 277461
+    assert turnout["turnout_percentage"] == 52.37
+    assert turnout["precincts_reported"] == "159 / 159 (100.00%)"
+
+
+def test_solano_extracts_contests_with_choices(fixtures_dir):
+    data = _solano_data(fixtures_dir)
+    titles = [c["title"] for c in data["contests"]]
+    assert any("PROPOSITION 50" in t.upper() for t in titles)
+
+    prop50 = next(c for c in data["contests"] if "PROPOSITION 50" in c["title"].upper())
+    names = {ch["name"] for ch in prop50["choices"]}
+    assert "YES" in names and "NO" in names
+
+    yes = next(ch for ch in prop50["choices"] if ch["name"] == "YES")
+    assert yes["votes"] == "92370"
+    assert yes["percentage"] == "63.67%"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,86 @@
+"""Tests for the URL whitelist and secure-filepath helpers.
+
+Both src/clarity_scraper.py and src/multi_platform_scraper.py define their
+own copies of validate_url and validate_and_secure_filepath. They are
+tested against the same expectations to catch drift between the two.
+"""
+
+import pytest
+
+from src import clarity_scraper as cs
+from src import multi_platform_scraper as mps
+
+
+SECURITY_MODULES = [cs, mps]
+
+
+@pytest.mark.parametrize("module", SECURITY_MODULES)
+class TestValidateUrl:
+    def test_accepts_whitelisted_domain(self, module):
+        url = "https://results.enr.clarityelections.com/CA/Marin/124182/web.345435/"
+        assert module.validate_url(url) == url
+
+    def test_accepts_subdomain_of_whitelisted(self, module):
+        url = "https://foo.clarityelections.com/x"
+        assert module.validate_url(url) == url
+
+    def test_rejects_unknown_domain(self, module):
+        with pytest.raises(ValueError, match="not in allowed list"):
+            module.validate_url("https://evil.example.com/x")
+
+    def test_rejects_localhost(self, module):
+        with pytest.raises(ValueError):
+            module.validate_url("http://localhost/admin")
+
+    def test_rejects_loopback_ip(self, module):
+        with pytest.raises(ValueError):
+            module.validate_url("http://127.0.0.1/admin")
+
+    def test_rejects_non_http_scheme(self, module):
+        with pytest.raises(ValueError, match="scheme"):
+            module.validate_url("file:///etc/passwd")
+
+    def test_rejects_lookalike_domain(self, module):
+        # netloc must equal allowed_domain or end with "." + allowed_domain.
+        # "evilclarityelections.com" must NOT match "clarityelections.com".
+        with pytest.raises(ValueError):
+            module.validate_url("https://evilclarityelections.com/x")
+
+
+@pytest.mark.parametrize("module", SECURITY_MODULES)
+class TestValidateAndSecureFilepath:
+    def test_returns_path_inside_base_dir(self, tmp_path, module):
+        result = module.validate_and_secure_filepath(tmp_path, "report", "csv")
+        assert result.is_relative_to(tmp_path.resolve())
+        assert result.suffix == ".csv"
+
+    def test_filename_includes_random_suffix(self, tmp_path, module):
+        a = module.validate_and_secure_filepath(tmp_path, "report", "csv")
+        b = module.validate_and_secure_filepath(tmp_path, "report", "csv")
+        assert a != b, "secrets-derived suffix should make filenames unique"
+
+    def test_rejects_disallowed_extension(self, tmp_path, module):
+        with pytest.raises(ValueError, match="extension"):
+            module.validate_and_secure_filepath(tmp_path, "report", "exe")
+
+    def test_accepts_each_allowed_extension(self, tmp_path, module):
+        for ext in module.ALLOWED_FILE_EXTENSIONS:
+            module.validate_and_secure_filepath(tmp_path, "report", ext)
+
+
+def test_clarity_whitelist_is_subset_of_multi_platform():
+    """clarity_scraper handles a narrower set of domains than
+    multi_platform_scraper, but every domain it permits must also be
+    permitted by the broader scraper. Drift in the other direction
+    means a Clarity-only domain was added without being shared, and is
+    almost always a copy-paste oversight."""
+    assert set(cs.ALLOWED_DOMAINS).issubset(set(mps.ALLOWED_DOMAINS))
+
+
+def test_clarity_whitelist_includes_clarity_domains():
+    for required in ("clarityelections.com", "results.enr.clarityelections.com"):
+        assert required in cs.ALLOWED_DOMAINS
+
+
+def test_two_modules_share_allowed_extensions():
+    assert cs.ALLOWED_FILE_EXTENSIONS == mps.ALLOWED_FILE_EXTENSIONS


### PR DESCRIPTION
Establishes a regression net for the project, which previously had no
automated tests. The suite covers the highest-risk surfaces: the
URL/path security helpers in both scraper modules, small pure helpers
on ClarityScraper, fixture-driven parser tests for Mendocino, Napa,
and Solano, and a JSON Schema check against every published sample
in data/samples/.

The new GitHub Actions workflow runs the suite on push and PR across
Python 3.10–3.12. setup.py's dev extra now includes jsonschema so
"pip install -e .[dev]" is sufficient to run tests locally.

48 tests, ~0.3s end-to-end.